### PR TITLE
1. 유저 프로필(처음 가입 시 깨짐) 수정 2. 프로필 이미지, 닉네임 변경 시 post 반영

### DIFF
--- a/prepare/back/routes/user.js
+++ b/prepare/back/routes/user.js
@@ -250,6 +250,19 @@ router.get("/:userId/posts", async (req, res, next) => {
             {
               model: Image,
             },
+            {
+              model: Post,
+              as: "Retweet",
+              include: [
+                {
+                  model: User,
+                  attributes: ["id", "nickname"],
+                },
+                {
+                  model: Image,
+                },
+              ],
+            },
           ],
         },
       ],

--- a/prepare/front/components/AletrtLoginModal.js
+++ b/prepare/front/components/AletrtLoginModal.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback } from "react";
 import { Dialog } from "@headlessui/react";
 import { useRouter } from "next/router";
 import { LockClosedIcon } from "@heroicons/react/24/outline";
@@ -6,9 +6,9 @@ import { LockClosedIcon } from "@heroicons/react/24/outline";
 const AlertLoginModal = () => {
   const router = useRouter();
 
-  const onGoLogin = () => {
+  const onGoLogin = useCallback(() => {
     router.push("/signin");
-  };
+  }, []);
 
   return (
     <>

--- a/prepare/front/components/NavbarForm.js
+++ b/prepare/front/components/NavbarForm.js
@@ -18,11 +18,9 @@ function classNames(...classes) {
 const NavbarForm = ({ me, children }) => {
   const router = useRouter();
   const dispatch = useDispatch();
-  // const { me } = useSelector((state) => state.user);
 
   useEffect(() => {
     dispatch(loadMyInfoRequest());
-    console.log("navbar me?.profileImg", me);
   }, []);
 
   const onLogout = useCallback(() => {
@@ -143,7 +141,7 @@ const NavbarForm = ({ me, children }) => {
                               alt=""
                             /> */}
                             {/* <UserIcon className="h-8 w-8 rounded-full text-white" /> */}
-                            {me.profileImg === "" ? (
+                            {me.profileImg === "" || me.profileImg === null ? (
                               <img
                                 alt="profile-img"
                                 src="https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png"

--- a/prepare/front/components/Profile.js
+++ b/prepare/front/components/Profile.js
@@ -105,7 +105,7 @@ const Profile = ({ me, postResult, wordResult }) => {
                   <div className="flex flex-wrap justify-center">
                     <div className=" w-full lg:w-3/12 px-4 lg:order-2 flex justify-center">
                       <div className="relative">
-                        {me.profileImg === "" ? (
+                        {me.profileImg === "" || me.profileImg === null ? (
                           <img
                             alt="profile-img"
                             src="https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png"

--- a/prepare/front/components/UserInfo.js
+++ b/prepare/front/components/UserInfo.js
@@ -6,7 +6,7 @@ const UserInfo = ({ nickname, me, postResult }) => {
     <>
       <div className="ml-2 shadow shadow-black-500/40 rounded-xl">
         <div className="md:flex lg:flex">
-          {me.profileImg === "" ? (
+          {me.profileImg === "" || me.profileImg === null ? (
             <img
               alt="profile-img"
               src="https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png"

--- a/prepare/front/components/post/PostCardContent.js
+++ b/prepare/front/components/post/PostCardContent.js
@@ -3,7 +3,6 @@ import { useCallback } from "react";
 import { useRouter } from "next/router";
 
 const PostCardContent = ({
-  images,
   content,
   editMode,
   onRevisePost,

--- a/prepare/front/pages/post.js
+++ b/prepare/front/pages/post.js
@@ -10,7 +10,8 @@ import { loadMyInfoRequest } from "../redux/feature/userSlice";
 
 const post = () => {
   const dispatch = useDispatch();
-  const { me } = useSelector((state) => state.user);
+  const { me, changeNicknameComplete, uploadProfileImageComplete } =
+    useSelector((state) => state.user);
   const { mainPosts, loadPostsLoading, hasMorePosts } = useSelector(
     (state) => state.post
   );
@@ -18,16 +19,18 @@ const post = () => {
   const postResult = mainPosts.filter((post) => post.UserId === id);
 
   useEffect(() => {
-    if (hasMorePosts && !loadPostsLoading) {
-      const lastId = mainPosts[mainPosts.length - 1]?.id;
-
-      dispatch(loadPostsRequest(lastId));
-    }
-  }, [hasMorePosts, mainPosts]);
-
-  useEffect(() => {
     dispatch(loadMyInfoRequest());
   }, []);
+
+  useEffect(() => {
+    if (hasMorePosts && !loadPostsLoading) {
+      const lastId = mainPosts[mainPosts.length - 1]?.id;
+      dispatch(loadPostsRequest(lastId));
+    }
+    if (changeNicknameComplete || uploadProfileImageComplete) {
+      window.location.reload();
+    }
+  }, [hasMorePosts, mainPosts]);
 
   return (
     <>


### PR DESCRIPTION
1. 로그인 하지 않은 유저의 프로필이 깨짐
▶ 조건을 `me.profileImg === "" `에서
`me.profileImg === "" || me.profileImg === null`으로 추가
▶ 첫 로그인 시(이미지 지정하지 않은 경우) me.profileImg === null이기 때문

2. 이미지, 유저 닉네임 변경 시 post 게시글의 이미지, 유저 닉네임도 변해야 함
▶ 닉네임이 변경되거나, 유저 프로필이 변경되는 경우
` if (changeNicknameComplete || uploadProfileImageComplete) {
      window.location.reload();
    }` 이렇게 적용(새로고침됨)
▶ window.location.reload()는 최대한 지양해야되나, 기존의 post를 불러오는 loadPostsRequest()에서 오류가 발생해 이렇게 적용됨