### PR TITLE
18. 특정 사용자 게시글, 해시태그 글 나오기 19.  post/[id]와 hashtag/[tag] 서로 중첩되지 않게 구현

### DIFF
--- a/prepare/back/routes/user.js
+++ b/prepare/back/routes/user.js
@@ -171,7 +171,7 @@ router.get("/:userId", async (req, res, next) => {
     const fullUserWithoutPassword = await User.findOne({
       where: { id: req.params.userId },
       attributes: {
-        exclude: ["password"],
+        exclude: ["password", "createdAt", "updatedAt"],
       },
       include: [
         {
@@ -220,7 +220,7 @@ router.get("/:userId/posts", async (req, res, next) => {
       include: [
         {
           model: User,
-          attributes: ["id", "nickname"],
+          attributes: ["id", "nickname", "profileImg"],
         },
         {
           model: Image,
@@ -230,7 +230,7 @@ router.get("/:userId/posts", async (req, res, next) => {
           include: [
             {
               model: User,
-              attributes: ["id", "nickname"],
+              attributes: ["id", "nickname", "profileImg"],
               order: [["createdAt", "DESC"]],
             },
           ],
@@ -238,7 +238,7 @@ router.get("/:userId/posts", async (req, res, next) => {
         {
           model: User, // 좋아요 누른 사람
           as: "Likers",
-          attributes: ["id"],
+          attributes: ["id", "nickname", "profileImg"],
         },
         {
           model: Post,
@@ -246,7 +246,7 @@ router.get("/:userId/posts", async (req, res, next) => {
           include: [
             {
               model: User,
-              attributes: ["id", "nickname"],
+              attributes: ["id", "nickname", "profileImg"],
             },
             {
               model: Image,
@@ -257,7 +257,7 @@ router.get("/:userId/posts", async (req, res, next) => {
               include: [
                 {
                   model: User,
-                  attributes: ["id", "nickname"],
+                  attributes: ["id", "nickname", "profileImg"],
                 },
                 {
                   model: Image,

--- a/prepare/front/components/UserInfo.js
+++ b/prepare/front/components/UserInfo.js
@@ -3,11 +3,13 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 
 const UserInfo = ({ nickname, me, postResult }) => {
+  console.log("me", me);
+
   return (
     <>
       <div className="ml-2 shadow shadow-black-500/40 rounded-xl">
         <div className="md:flex lg:flex">
-          {me.profileImg === "" || me.profileImg === null ? (
+          {me?.profileImg === "" || me?.profileImg === null ? (
             <img
               alt="profile-img"
               src="https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png"
@@ -16,8 +18,8 @@ const UserInfo = ({ nickname, me, postResult }) => {
           ) : (
             <img
               className="rounded-lg w-14 h-14 mt-2 ml-1"
-              src={`http://localhost:3005/userImg/${me.profileImg}`}
-              alt={me.profileImg}
+              src={`http://localhost:3005/userImg/${me?.profileImg}`}
+              alt={me?.profileImg}
             />
           )}
           <div className="ml-1">
@@ -31,7 +33,7 @@ const UserInfo = ({ nickname, me, postResult }) => {
               <Link
                 href={{
                   pathname: "/user/[id]",
-                  query: { id: me.id },
+                  query: { id: me?.id },
                 }}
                 prefetch={false}
               >
@@ -43,7 +45,11 @@ const UserInfo = ({ nickname, me, postResult }) => {
             <p className="text-gray-400 block">Follower</p>
             <p className="ml-1 font-bold cursor-pointer">
               <Link href={`/profile`}>
-                <a>{me?.Followers.length}</a>
+                <a>
+                  {me?.Followers.length >= 0
+                    ? me?.Followers.length
+                    : me?.Followers}
+                </a>
               </Link>
             </p>
           </div>
@@ -51,7 +57,11 @@ const UserInfo = ({ nickname, me, postResult }) => {
             <p className="text-gray-400 block">Following</p>
             <p className="ml-1 font-bold cursor-pointer">
               <Link href={`/profile`}>
-                <a>{me?.Followings.length}</a>
+                <a>
+                  {me?.Followings.length >= 0
+                    ? me?.Followings.length
+                    : me?.Followings}
+                </a>
               </Link>
             </p>
           </div>

--- a/prepare/front/components/post/PostCard.js
+++ b/prepare/front/components/post/PostCard.js
@@ -259,18 +259,14 @@ const PostCard = ({ post, index, me }) => {
             <>
               <PostImages images={post?.Images} />
 
-              <div
-                className="cursor-pointer"
-                onClick={singlePost ? null : onPostDetail}
-              >
-                <PostCardContent
-                  editMode={editMode}
-                  onCancleRevisePost={onCancleRevisePost}
-                  onRevisePost={onRevisePost}
-                  content={post?.content}
-                  index={index}
-                />
-              </div>
+              <PostCardContent
+                id={post?.id}
+                editMode={editMode}
+                onCancleRevisePost={onCancleRevisePost}
+                onRevisePost={onRevisePost}
+                content={post?.content}
+                index={index}
+              />
             </>
           )}
 

--- a/prepare/front/components/post/PostCardContent.js
+++ b/prepare/front/components/post/PostCardContent.js
@@ -3,15 +3,21 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 
 const PostCardContent = ({
+  id,
   content,
   editMode,
   onRevisePost,
   onCancleRevisePost,
   index,
 }) => {
+  const router = useRouter();
   const [editText, setEditText] = useState(content);
   const onChangeText = useCallback((e) => {
     setEditText(e.target.value);
+  }, []);
+
+  const onPostDetail = useCallback(() => {
+    router.push(`/post/${id}`);
   }, []);
 
   return (
@@ -51,13 +57,19 @@ const PostCardContent = ({
                   <>
                     <div key={i} className="float-left mx-1">
                       <Link className="" href={`/hashtag/${v.slice(1)}`}>
-                        <p className="text-sky-500">{v}</p>
+                        <p className="cursor-pointer text-sky-500">{v}</p>
                       </Link>
                     </div>
                   </>
                 );
               }
-              return v;
+              return (
+                <>
+                  <div className="cursor-pointer" onClick={onPostDetail}>
+                    {v}
+                  </div>
+                </>
+              );
             })}
           </div>
           <small className="text-gray-400 m-5 float-right ml-2">

--- a/prepare/front/pages/hashtag/[tag].js
+++ b/prepare/front/pages/hashtag/[tag].js
@@ -1,0 +1,105 @@
+import axios from "axios";
+import Head from "next/head";
+import { useRouter } from "next/router";
+import { useCallback, useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { END } from "redux-saga";
+
+import NavbarForm from "../../components/NavbarForm";
+import PostCard from "../../components/post/PostCard";
+import UserInfo from "../../components/UserInfo";
+import {
+  loadHashtagPostsRequest,
+  loadUserPostsRequest,
+} from "../../redux/feature/postSlice";
+import {
+  loadMyInfoRequest,
+  loadUserRequest,
+} from "../../redux/feature/userSlice";
+import wrapper from "../../redux/store";
+
+const Hashtag = () => {
+  const dispatch = useDispatch();
+  const router = useRouter();
+  const { tag } = router.query;
+
+  const { mainPosts, hasMorePosts, loadPostsLoading } = useSelector(
+    (state) => state.post
+  );
+  const { me } = useSelector((state) => state.user);
+
+  useEffect(() => {
+    if (hasMorePosts && !loadPostsLoading) {
+      const lastId = mainPosts[mainPosts.length - 1]?.id;
+      dispatch(loadUserPostsRequest(lastId, tag));
+    }
+  }, [hasMorePosts, loadPostsLoading, mainPosts, tag]);
+
+  const onGoSNS = useCallback(() => {
+    router.push("/post");
+  }, []);
+
+  return (
+    <NavbarForm>
+      <Head>
+        {/* <title>{`title ${userInfo?.nickname}님의 작성 게시글`}</title>
+        <meta name="description" content={`${userInfo?.content}`} />
+        <meta
+          property="og:title"
+          content={`${userInfo?.nickname}님의 작성 게시글`}
+        />
+        <meta property="og:description" content={userInfo?.content} />
+        <meta property="og:image" content="https://engword.shop/favicon.ico" />
+        <meta property="og:url" content={`https://engword.shop/post/${id}`} /> */}
+      </Head>
+
+      <div className="h-full mt-5">
+        <div className="grid grid-cols-4 gap-6">
+          <div className="col-span-1">
+            <div className=" text-center ml-2 shadow shadow-black-500/40 rounded-xl">
+              <div className="md:flex lg:flex">
+                <div className="ml-1">
+                  <p className="font-bold p-1 mt-1 lg:mt-5">
+                    <span className="text-sky-500">#{tag}</span> 결과
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div className="col-span-2">
+            <div className="flex justify-center">
+              <button
+                onClick={onGoSNS}
+                className="px-3 py-2 font-medium rounded-lg bg-light-green text-white hover:bg-light-beige hover:text-black"
+              >
+                게시글로 돌아가기
+              </button>
+            </div>
+            {mainPosts.map((post, index) => {
+              return <PostCard key={index} post={post} index={index} me={me} />;
+            })}
+          </div>
+          <div className="col-span-1"></div>
+        </div>
+      </div>
+    </NavbarForm>
+  );
+};
+
+export const getServerSideProps = wrapper.getServerSideProps(
+  async (context) => {
+    const cookie = context.req ? context.req.headers.cookie : "";
+    axios.defaults.headers.Cookie = "";
+    if (context.req && cookie) {
+      axios.defaults.headers.Cookie = cookie;
+    }
+
+    context.store.dispatch(loadHashtagPostsRequest(context.params.tag));
+    context.store.dispatch(loadMyInfoRequest());
+
+    context.store.dispatch(END);
+    await context.store.sagaTask.toPromise();
+  }
+);
+
+export default Hashtag;

--- a/prepare/front/pages/user/[id].js
+++ b/prepare/front/pages/user/[id].js
@@ -1,0 +1,100 @@
+import axios from "axios";
+import Head from "next/head";
+import { useRouter } from "next/router";
+import { useCallback, useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { END } from "redux-saga";
+
+import NavbarForm from "../../components/NavbarForm";
+import PostCard from "../../components/post/PostCard";
+import UserInfo from "../../components/UserInfo";
+import { loadUserPostsRequest } from "../../redux/feature/postSlice";
+import {
+  loadMyInfoRequest,
+  loadUserRequest,
+} from "../../redux/feature/userSlice";
+import wrapper from "../../redux/store";
+
+const User = () => {
+  const dispatch = useDispatch();
+  const router = useRouter();
+  const { id } = router.query;
+
+  const { mainPosts, hasMorePosts, loadPostsLoading } = useSelector(
+    (state) => state.post
+  );
+  const { userInfo, me } = useSelector((state) => state.user);
+  const postResult = mainPosts;
+
+  useEffect(() => {
+    if (hasMorePosts && !loadPostsLoading) {
+      const lastId = mainPosts[mainPosts.length - 1]?.id;
+      dispatch(loadUserPostsRequest(lastId, id));
+    }
+  }, [hasMorePosts, loadPostsLoading, mainPosts, id]);
+
+  const onGoSNS = useCallback(() => {
+    router.push("/post");
+  }, []);
+
+  return (
+    <NavbarForm>
+      <Head>
+        <title>{`title ${userInfo?.nickname}님의 작성 게시글`}</title>
+        <meta name="description" content={`${userInfo?.content}`} />
+        <meta
+          property="og:title"
+          content={`${userInfo?.nickname}님의 작성 게시글`}
+        />
+        <meta property="og:description" content={userInfo?.content} />
+        <meta property="og:image" content="https://engword.shop/favicon.ico" />
+        <meta property="og:url" content={`https://engword.shop/post/${id}`} />
+      </Head>
+
+      <div className="h-full mt-5">
+        <div className="grid grid-cols-4 gap-6">
+          <div className="col-span-1">
+            <UserInfo
+              nickname={userInfo?.nickname}
+              me={userInfo}
+              postResult={postResult}
+            />
+          </div>
+          <div className="col-span-2">
+            <div className="flex justify-center">
+              <button
+                onClick={onGoSNS}
+                className="px-3 py-2 font-medium rounded-lg bg-light-green text-white hover:bg-light-beige hover:text-black"
+              >
+                게시글로 돌아가기
+              </button>
+            </div>
+            {mainPosts.map((post, index) => {
+              return <PostCard key={index} post={post} index={index} me={me} />;
+            })}
+          </div>
+          <div className="col-span-1"></div>
+        </div>
+      </div>
+    </NavbarForm>
+  );
+};
+
+export const getServerSideProps = wrapper.getServerSideProps(
+  async (context) => {
+    const cookie = context.req ? context.req.headers.cookie : "";
+    axios.defaults.headers.Cookie = "";
+    if (context.req && cookie) {
+      axios.defaults.headers.Cookie = cookie;
+    }
+
+    context.store.dispatch(loadUserPostsRequest(context.params.id));
+    context.store.dispatch(loadMyInfoRequest());
+
+    context.store.dispatch(loadUserRequest(context.params.id));
+    context.store.dispatch(END);
+    await context.store.sagaTask.toPromise();
+  }
+);
+
+export default User;

--- a/prepare/front/redux/feature/postSlice.js
+++ b/prepare/front/redux/feature/postSlice.js
@@ -207,6 +207,7 @@ export const postSlice = createSlice({
     },
     loadUserPostsSuccess: (state, action) => {
       const data = action.payload;
+      console.log("결과", data);
       state.loadPostsLoading = false;
       state.loadPostsComplete = true;
       state.mainPosts = state.mainPosts.concat(data);

--- a/prepare/front/redux/feature/userSlice.js
+++ b/prepare/front/redux/feature/userSlice.js
@@ -13,6 +13,9 @@ const initialState = {
   loadMyInfoLoading: false, //내 정보 가져오기
   loadMyInfoComplete: false,
   loadMyInfoError: null,
+  loadUserLoading: false, // 유저 정보 가져오기
+  loadUserDone: false,
+  loadUserError: null,
   changeNicknameLoading: false, //닉네임 변경
   changeNicknameComplete: false,
   changeNicknameError: null,
@@ -44,6 +47,7 @@ const initialState = {
   uploadProfileImageComplete: false,
   uploadProfileImageError: null,
   me: null,
+  userInfo: null,
   imagePaths: [],
   signUpData: {},
   loginData: {},
@@ -115,6 +119,20 @@ export const userSlice = createSlice({
     loadMyInfoFailure: (state, action) => {
       state.loadMyInfoLoading = false;
       state.loadMyInfoError = action.error;
+    },
+    loadUserRequest: (state) => {
+      state.loadUserLoading = true;
+      state.loadUserError = null;
+      state.loadUserComplete = false;
+    },
+    loadUserSuccess: (state, action) => {
+      state.loadUserLoading = false;
+      state.loadUserComplete = true;
+      state.userInfo = action.payload;
+    },
+    loadUserFailure: (state, action) => {
+      state.loadUserLoading = false;
+      state.loadUserError = action.error;
     },
     //닉네임 변경
     changeNicknameRequest: (state) => {
@@ -299,6 +317,9 @@ export const {
   loadMyInfoRequest,
   loadMyInfoSuccess,
   loadMyInfoFailure,
+  loadUserRequest,
+  loadUserSuccess,
+  loadUserFailure,
   changeNicknameRequest,
   changeNicknameSuccess,
   changeNicknameFailure,

--- a/prepare/front/redux/sagas/postSaga.js
+++ b/prepare/front/redux/sagas/postSaga.js
@@ -185,9 +185,8 @@ function loadUserPostsAPI(data, lastId) {
 function* loadUserPosts(action) {
   try {
     const data = action.payload;
-    console.log("data", data);
-    const result = yield call(loadUserPostsAPI, data, lastId);
-    console.log("result.data", result.data);
+    console.log("Data", data);
+    const result = yield call(loadUserPostsAPI, data);
     yield put(loadUserPostsSuccess(result.data));
   } catch (error) {
     yield put(loadUserPostsFailure(error));

--- a/prepare/front/redux/sagas/userSaga.js
+++ b/prepare/front/redux/sagas/userSaga.js
@@ -12,6 +12,9 @@ import {
   loadMyInfoRequest,
   loadMyInfoSuccess,
   loadMyInfoFailure,
+  loadUserRequest,
+  loadUserSuccess,
+  loadUserFailure,
   changeNicknameRequest,
   changeNicknameSuccess,
   changeNicknameFailure,
@@ -101,6 +104,22 @@ function* loadMyInfo(action) {
     yield put(loadMyInfoSuccess(result.data));
   } catch (error) {
     yield put(loadMyInfoFailure(error));
+    console.log(error);
+  }
+}
+
+function loadUserAPI(data) {
+  return axios.get(`/user/${data}`);
+}
+
+function* loadUser(action) {
+  try {
+    const data = action.payload;
+    const result = yield call(loadUserAPI, data);
+    console.log("result.data", result.data);
+    yield put(loadUserSuccess(result.data));
+  } catch (error) {
+    yield put(loadUserFailure(error));
     console.log(error);
   }
 }
@@ -274,6 +293,10 @@ function* loadmyinfo_Req() {
   yield takeLatest(loadMyInfoRequest.type, loadMyInfo);
 }
 
+function* loaduser_Req() {
+  yield takeLatest(loadUserRequest.type, loadUser);
+}
+
 function* changenickname_Req() {
   yield takeLatest(changeNicknameRequest.type, changeNickname);
 }
@@ -319,6 +342,7 @@ export const userSagas = [
   fork(logout_Req),
   fork(signup_Req),
   fork(loadmyinfo_Req),
+  fork(loaduser_Req),
   fork(changenickname_Req),
   fork(follow_Req),
   fork(unfollow_Req),


### PR DESCRIPTION

18. 다이나믹 라우팅 이용
특정 사용자가 쓴 게시글 검색 
▶ user/[id].js, loadPostRequest(context.params.id) 이용, UserInfo 컴포넌트 재사용
 해시태그 검색 
▶ hashtag/[tag].js, loadHashtagPostsRequest() 이용

19. 게시글에 해시태그 존재 시 post/[id]와 hashtag/[tag]가 서로 중복으로 검색
▶ PostCardContent에 id={post?.id}를 props로 전달
▶ Hashtag 부분은 해시태그 검색만, 게시글 본문은 onPostDetail 함수를 통해 router.push(`/post/${id}`); 이동
