### PR TITLE
29. 게시글, 해시태그 검색 30. lastId와 useInView 이용한 10개씩 스크롤 하기

### DIFF
--- a/prepare/back/routes/hashtag.js
+++ b/prepare/back/routes/hashtag.js
@@ -6,7 +6,12 @@ const { Op } = require("sequelize");
 router.get("/:hashtag", async (req, res, next) => {
   // GET /hashtag/노드
   try {
-    const where = {};
+    const hashtag = req.params.hashtag;
+    const where = {
+      content: {
+        [Op.like]: `%#${decodeURIComponent(hashtag)}%`,
+      },
+    };
     if (parseInt(req.query.lastId, 10)) {
       // 초기 로딩이 아닐때
       where.id = { [Op.lt]: parseInt(req.query.lastId, 10) };
@@ -18,7 +23,6 @@ router.get("/:hashtag", async (req, res, next) => {
       include: [
         {
           model: Hashtag,
-          where: { name: decodeURIComponent(req.params.hashtag) },
         },
         {
           model: User,

--- a/prepare/front/components/UserInfo.js
+++ b/prepare/front/components/UserInfo.js
@@ -1,8 +1,7 @@
-import React, { useCallback, useState } from "react";
+import React from "react";
 import Link from "next/link";
-import { useRouter } from "next/router";
 
-const UserInfo = ({ nickname, me, postResult }) => {
+const UserInfo = ({ nickname, me, mainPosts }) => {
   return (
     <>
       <div className="ml-2 shadow shadow-black-500/40 rounded-xl">
@@ -35,7 +34,9 @@ const UserInfo = ({ nickname, me, postResult }) => {
                 }}
                 prefetch={false}
               >
-                <a>{postResult.length}</a>
+                <a>
+                  {mainPosts?.filter((post) => post.UserId === me?.id).length}
+                </a>
               </Link>
             </p>
           </div>

--- a/prepare/front/components/post/NonPostModal.js
+++ b/prepare/front/components/post/NonPostModal.js
@@ -1,24 +1,19 @@
 import { Fragment, useRef, useState, useCallback } from "react";
-import { useDispatch } from "react-redux";
 import { Dialog, Transition } from "@headlessui/react";
-import { ExclamationTriangleIcon } from "@heroicons/react/24/outline";
-import { removePostRequest } from "../../redux/feature/postSlice";
+import {
+  FaceFrownIcon,
+  MagnifyingGlassIcon,
+} from "@heroicons/react/24/outline";
+import PostSearch from "./PostSearch";
+import { useRouter } from "next/router";
 
-const RemovePostModal = ({ PostIndex, setRemoveModal }) => {
-  const dispatch = useDispatch();
+const NonPostModal = ({ content }) => {
+  const router = useRouter();
   const [open, setOpen] = useState(true);
-
   const cancelButtonRef = useRef(null);
 
-  const onRemovePostModal = useCallback(() => {
-    setRemoveModal(false);
-    dispatch(removePostRequest(PostIndex));
-  }, []);
-
-  const onOpenCloseModal = useCallback(() => {
-    console.log("open", open);
-    setRemoveModal(false);
-    setOpen(!open);
+  const onGoSNS = useCallback(() => {
+    router.push("/post");
   }, []);
 
   return (
@@ -56,7 +51,7 @@ const RemovePostModal = ({ PostIndex, setRemoveModal }) => {
                 <div className="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
                   <div className="sm:flex sm:items-start">
                     <div className="mx-auto flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-red-100 sm:mx-0 sm:h-10 sm:w-10">
-                      <ExclamationTriangleIcon
+                      <FaceFrownIcon
                         className="h-6 w-6 text-red-600"
                         aria-hidden="true"
                       />
@@ -66,19 +61,23 @@ const RemovePostModal = ({ PostIndex, setRemoveModal }) => {
                         as="h3"
                         className="text-lg font-medium leading-6 text-gray-900"
                       >
-                        게시글을
-                        <span className="text-red-500 font-bold"> 삭제</span>
-                        하시겠습니까?
+                        검색한
+                        <span className="text-red-500 font-bold">
+                          {" "}
+                          {content}
+                        </span>
+                        를 찾을 수 없습니다.
                       </Dialog.Title>
-                      <div className="mt-2">
-                        <p className="text-sm text-gray-500">
-                          <span className="text-red-500 font-bold">삭제 </span>
-                          이후에는 해당 게시글은{" "}
-                          <span className="text-red-500 font-bold">
-                            다시 생성
-                          </span>
-                          해야 합니다.
+                      <div className="mt-2 bg-gray-100 w-96 h-20 rounded-md">
+                        <p className="pt-2  font-bold flex place-content-center">
+                          검색은{" "}
+                          <MagnifyingGlassIcon className="w-5 h-5 text-red-500" />
+                          를 눌러주세요.
                         </p>
+
+                        <div className="w-11/12 ml-2">
+                          <PostSearch />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -87,17 +86,9 @@ const RemovePostModal = ({ PostIndex, setRemoveModal }) => {
                   <button
                     type="button"
                     className="inline-flex w-full justify-center rounded-md border border-transparent bg-red-600 px-4 py-2 text-base font-medium text-white shadow-sm hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 sm:ml-3 sm:w-auto sm:text-sm"
-                    onClick={onRemovePostModal}
+                    onClick={onGoSNS}
                   >
-                    삭제
-                  </button>
-                  <button
-                    type="button"
-                    className="mt-3 inline-flex w-full justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-base font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm"
-                    onClick={onOpenCloseModal}
-                    ref={cancelButtonRef}
-                  >
-                    취소
+                    게시글로 돌아가기
                   </button>
                 </div>
               </Dialog.Panel>
@@ -109,4 +100,4 @@ const RemovePostModal = ({ PostIndex, setRemoveModal }) => {
   );
 };
 
-export default RemovePostModal;
+export default NonPostModal;

--- a/prepare/front/components/post/PostSearch.js
+++ b/prepare/front/components/post/PostSearch.js
@@ -1,15 +1,20 @@
 import React, { useCallback } from "react";
 import { MagnifyingGlassIcon } from "@heroicons/react/24/outline";
 import useInput from "../../hooks/useInput";
+import { useRouter } from "next/router";
+import { useSelector } from "react-redux";
 
 const PostSearch = () => {
+  const { mainPosts } = useSelector((state) => state.post);
+  const router = useRouter();
   const [detail, onChangeDetail] = useInput("");
 
   const onSearch = useCallback(() => {
     if (!detail) {
       alert("아무것도 검색하지 않았습니다.");
+    } else {
+      router.replace(`/search/${detail}`);
     }
-    console.log("detail", detail);
   }, [detail]);
   return (
     <div className="mt-2 ml-2 w-full mx-auto block">

--- a/prepare/front/package-lock.json
+++ b/prepare/front/package-lock.json
@@ -27,6 +27,7 @@
         "react": "^18.2.0",
         "react-chartjs-2": "^5.1.0",
         "react-dom": "^18.2.0",
+        "react-intersection-observer": "^9.4.1",
         "react-redux": "^8.0.4",
         "redux": "^4.2.0",
         "redux-logger": "^3.0.6",
@@ -4090,6 +4091,14 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-intersection-observer": {
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.4.1.tgz",
+      "integrity": "sha512-IXpIsPe6BleFOEHKzKh5UjwRUaz/JYS0lT/HPsupWEQou2hDqjhLMStc5zyE3eQVT4Fk3FufM8Fw33qW1uyeiw==",
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
@@ -7679,6 +7688,12 @@
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
       }
+    },
+    "react-intersection-observer": {
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.4.1.tgz",
+      "integrity": "sha512-IXpIsPe6BleFOEHKzKh5UjwRUaz/JYS0lT/HPsupWEQou2hDqjhLMStc5zyE3eQVT4Fk3FufM8Fw33qW1uyeiw==",
+      "requires": {}
     },
     "react-is": {
       "version": "18.2.0",

--- a/prepare/front/package.json
+++ b/prepare/front/package.json
@@ -29,6 +29,7 @@
     "react": "^18.2.0",
     "react-chartjs-2": "^5.1.0",
     "react-dom": "^18.2.0",
+    "react-intersection-observer": "^9.4.1",
     "react-redux": "^8.0.4",
     "redux": "^4.2.0",
     "redux-logger": "^3.0.6",

--- a/prepare/front/pages/post/[id].js
+++ b/prepare/front/pages/post/[id].js
@@ -15,6 +15,7 @@ const Post = () => {
   const router = useRouter();
   const { id } = router.query;
   const { singlePost } = useSelector((state) => state.post);
+  console.log("id", id, "siglePost", singlePost);
 
   const onGoSNS = useCallback(() => {
     router.push("/post");

--- a/prepare/front/pages/post/index.js
+++ b/prepare/front/pages/post/index.js
@@ -3,6 +3,7 @@ import { useRouter } from "next/router";
 import React, { useCallback, useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { END } from "redux-saga";
+import { useInView } from "react-intersection-observer";
 
 import NavbarForm from "../../components/NavbarForm";
 import PostCard from "../../components/post/PostCard";
@@ -15,7 +16,7 @@ import { loadMyInfoRequest } from "../../redux/feature/userSlice";
 import { loadWordsWeekendRequest } from "../../redux/feature/wordSlice";
 import wrapper from "../../redux/store";
 
-const post = () => {
+const Index = () => {
   const dispatch = useDispatch();
   const router = useRouter();
   const { me } = useSelector((state) => state.user);
@@ -28,8 +29,7 @@ const post = () => {
     bookmarkError,
   } = useSelector((state) => state.post);
   const { weekendResult, wordLists } = useSelector((state) => state.word);
-  const id = useSelector((state) => state.user.me?.id);
-  const postResult = mainPosts.filter((post) => post.UserId === id);
+  const [ref, inView] = useInView();
 
   const onBookmark = useCallback(() => {
     router.push("/bookmark");
@@ -59,11 +59,12 @@ const post = () => {
 
   useEffect(() => {
     console.log("mainPosts", mainPosts);
-    if (hasMorePosts && !loadPostsLoading) {
+    if (inView && hasMorePosts && !loadPostsLoading) {
       const lastId = mainPosts[mainPosts.length - 1]?.id;
       dispatch(loadPostsRequest(lastId));
+      console.log("lastId", lastId);
     }
-  }, [hasMorePosts, loadPostsLoading, mainPosts]);
+  }, [inView, hasMorePosts, loadPostsLoading, mainPosts]);
 
   return (
     <>
@@ -76,7 +77,7 @@ const post = () => {
                   <UserInfo
                     nickname={me?.nickname}
                     me={me}
-                    postResult={postResult}
+                    mainPosts={mainPosts}
                   />
                   <div
                     className="bg-gray-100 ml-2 mt-2 rounded-xl"
@@ -97,6 +98,10 @@ const post = () => {
                   <PostCard key={index} post={post} index={index} me={me} />
                 );
               })}
+              <div
+                ref={hasMorePosts && !loadPostsLoading ? ref : undefined}
+                className="h-10"
+              />
             </div>
             {weekendResult.length > 0 ? (
               <div className="mt-10">
@@ -125,4 +130,4 @@ export const getServerSideProps = wrapper.getServerSideProps(
   }
 );
 
-export default post;
+export default Index;

--- a/prepare/front/pages/search/[content].js
+++ b/prepare/front/pages/search/[content].js
@@ -1,0 +1,123 @@
+import axios from "axios";
+import Head from "next/head";
+import { useRouter } from "next/router";
+import { useCallback, useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { END } from "redux-saga";
+import { useInView } from "react-intersection-observer";
+
+import NavbarForm from "../../components/NavbarForm";
+import NonPostModal from "../../components/post/NonPostModal";
+import PostCard from "../../components/post/PostCard";
+import PostSearch from "../../components/post/PostSearch";
+import { loadSearchPostsRequest } from "../../redux/feature/postSlice";
+import { loadMyInfoRequest } from "../../redux/feature/userSlice";
+import wrapper from "../../redux/store";
+
+const Search = () => {
+  const dispatch = useDispatch();
+  const router = useRouter();
+  const { content } = router.query;
+
+  const { mainPosts, hasMorePosts, loadPostsLoading } = useSelector(
+    (state) => state.post
+  );
+  const { me } = useSelector((state) => state.user);
+  const [ref, inView] = useInView();
+
+  useEffect(() => {
+    if (inView && hasMorePosts && !loadPostsLoading) {
+      const lastId = mainPosts[mainPosts.length - 1]?.id;
+      dispatch(loadSearchPostsRequest({ lastId: lastId, data: content }));
+    }
+  }, [inView, hasMorePosts, loadPostsLoading, mainPosts, content]);
+
+  const onGoSNS = useCallback(() => {
+    router.push("/post");
+  }, []);
+
+  return (
+    <NavbarForm>
+      <Head>
+        <title>{`#${content}로 찾은 게시글`}</title>
+        <meta name="description" content={`${content}`} />
+        <meta property="og:title" content={`#${content}로 찾은 게시글`} />
+        <meta property="og:description" content={content} />
+        <meta property="og:image" content="https://engword.shop/favicon.ico" />
+        <meta
+          property="og:url"
+          content={`https://engword.shop/search/${content}`}
+        />
+      </Head>
+
+      <div className="h-full mt-5">
+        <div className="grid grid-cols-4 gap-6">
+          {mainPosts.length > 0 ? (
+            <div className="col-span-1">
+              <div className=" text-center ml-2 shadow shadow-black-500/40 rounded-xl">
+                <div className="flex place-content-center">
+                  <div className="ml-1">
+                    <p className="font-bold p-1 mt-1">
+                      <span className="text-light-orange lg:text-lg">
+                        "{content}"
+                      </span>{" "}
+                      결과
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <PostSearch />
+            </div>
+          ) : null}
+
+          <div className="col-span-2">
+            {mainPosts.length > 0 ? (
+              <>
+                <div className="flex justify-center">
+                  <button
+                    onClick={onGoSNS}
+                    className="px-3 py-2 font-medium rounded-lg bg-light-green text-white hover:bg-light-beige hover:text-black"
+                  >
+                    게시글로 돌아가기
+                  </button>
+                </div>
+                {mainPosts.map((post, index) => {
+                  return (
+                    <PostCard key={index} post={post} index={index} me={me} />
+                  );
+                })}
+                <div
+                  ref={hasMorePosts && !loadPostsLoading ? ref : undefined}
+                  className="h-10"
+                />
+              </>
+            ) : (
+              <NonPostModal content={content} />
+            )}
+          </div>
+
+          <div className="col-span-1"></div>
+        </div>
+      </div>
+    </NavbarForm>
+  );
+};
+
+export const getServerSideProps = wrapper.getServerSideProps(
+  async (context) => {
+    const cookie = context.req ? context.req.headers.cookie : "";
+    axios.defaults.headers.Cookie = "";
+    if (context.req && cookie) {
+      axios.defaults.headers.Cookie = cookie;
+    }
+
+    context.store.dispatch(
+      loadSearchPostsRequest({ data: context.params.content })
+    );
+    context.store.dispatch(loadMyInfoRequest());
+    context.store.dispatch(END);
+    await context.store.sagaTask.toPromise();
+  }
+);
+
+export default Search;

--- a/prepare/front/pages/user/[id].js
+++ b/prepare/front/pages/user/[id].js
@@ -57,7 +57,7 @@ const User = () => {
             <UserInfo
               nickname={userInfo?.nickname}
               me={userInfo}
-              postResult={postResult}
+              mainPosts={mainPosts}
             />
           </div>
           <div className="col-span-2">

--- a/prepare/front/redux/feature/postSlice.js
+++ b/prepare/front/redux/feature/postSlice.js
@@ -227,7 +227,6 @@ export const postSlice = createSlice({
     },
     loadUserPostsSuccess: (state, action) => {
       const data = action.payload;
-      console.log("결과", data);
       state.loadPostsLoading = false;
       state.loadPostsComplete = true;
       state.mainPosts = state.mainPosts.concat(data);
@@ -250,6 +249,22 @@ export const postSlice = createSlice({
       state.hasMorePosts = data.length === 10;
     },
     loadHashtagPostsFailure: (state, action) => {
+      state.loadPostsLoading = false;
+      state.loadPostsError = action.error;
+    },
+    loadSearchPostsRequest: (state) => {
+      state.loadPostsLoading = true;
+      state.loadPostsError = null;
+      state.loadPostsComplete = false;
+    },
+    loadSearchPostsSuccess: (state, action) => {
+      const data = action.payload;
+      state.loadPostsLoading = false;
+      state.loadPostsComplete = true;
+      state.mainPosts = state.mainPosts.concat(data);
+      state.hasMorePosts = data.length === 10;
+    },
+    loadSearchPostsFailure: (state, action) => {
       state.loadPostsLoading = false;
       state.loadPostsError = action.error;
     },
@@ -455,6 +470,9 @@ export const {
   loadHashtagPostsRequest,
   loadHashtagPostsSuccess,
   loadHashtagPostsFailure,
+  loadSearchPostsRequest,
+  loadSearchPostsSuccess,
+  loadSearchPostsFailure,
   likePostRequest,
   likePostSuccess,
   likePostFailure,

--- a/prepare/front/redux/sagas/postSaga.js
+++ b/prepare/front/redux/sagas/postSaga.js
@@ -31,6 +31,9 @@ import {
   loadHashtagPostsRequest,
   loadHashtagPostsSuccess,
   loadHashtagPostsFailure,
+  loadSearchPostsRequest,
+  loadSearchPostsSuccess,
+  loadSearchPostsFailure,
   likePostRequest,
   likePostSuccess,
   likePostFailure,
@@ -192,7 +195,6 @@ function loadUserPostsAPI(data, lastId) {
 function* loadUserPosts(action) {
   try {
     const data = action.payload;
-    console.log("Data", data);
     const result = yield call(loadUserPostsAPI, data);
     yield put(loadUserPostsSuccess(result.data));
   } catch (error) {
@@ -209,12 +211,33 @@ function loadHashtagPostsAPI(data, lastId) {
 
 function* loadHashtagPosts(action) {
   try {
-    const data = action.payload;
-    const lastId = action.payload;
+    const data = action.payload.data;
+    const lastId = action.payload?.lastId;
     const result = yield call(loadHashtagPostsAPI, data, lastId);
     yield put(loadHashtagPostsSuccess(result.data));
   } catch (error) {
     yield put(loadHashtagPostsFailure(error));
+    console.log(error);
+  }
+}
+
+//loadSearchPosts
+function loadSearchPostsAPI(data, lastId) {
+  return axios.get(
+    `/posts/search/${encodeURIComponent(data)}?lastId=${lastId || 0}`
+  ); //data로 넘어갔으므로 req.query.data?
+}
+
+function* loadSearchPosts(action) {
+  try {
+    console.log("action.payload", action.payload);
+    const data = action.payload.data;
+    const lastId = action.payload?.lastId;
+    const result = yield call(loadSearchPostsAPI, data, lastId);
+    console.log("result.data", result.data);
+    yield put(loadSearchPostsSuccess(result.data));
+  } catch (error) {
+    yield put(loadSearchPostsFailure(error));
     console.log(error);
   }
 }
@@ -382,6 +405,10 @@ function* loadHashtagPosts_Req() {
   yield takeLatest(loadHashtagPostsRequest.type, loadHashtagPosts);
 }
 
+function* loadSearchPosts_Req() {
+  yield takeLatest(loadSearchPostsRequest.type, loadSearchPosts);
+}
+
 function* likePost_Req() {
   yield takeLatest(likePostRequest.type, likePost);
 }
@@ -425,6 +452,7 @@ export const postSagas = [
   fork(loadPost_Req),
   fork(loadUserPosts_Req),
   fork(loadHashtagPosts_Req),
+  fork(loadSearchPosts_Req),
   fork(likePost_Req),
   fork(unlikePost_Req),
   fork(uploadImages_Req),


### PR DESCRIPTION
29. 게시글과 해시태그 검색을 다르게 적용 

▶ 게시글 검색의 경우 검색창(`PostSearch.js`)에 `cat` 입력 시 `/search/cat`으로 이동
 ▶ `#해시태그`로 써 있는 부분을 누르면 `/hastag/해시태그` 이동
▶ 게시글 검색의 경우 해시태그의 내용도 포괄해서 검색 가능(게시글 검색이 더 많은 정보를 찾아줌)
▶ 검색한 내용이 없을 경우 경고창(`NonPostModal.js`)과 함께 검색창(`PostSearch.js`)가 나오게 함

30. `react-intersection-observer` 내 `useInView` 를 불러와서 lastId로 게시글 조회하기

▶  한 번에 10개씩 불러오며, 10개 -> 10 + 10 -> 10 + 10 + 10 이런식으로 진행됨
▶ `useInView`로 ` const [ref, inView] = useInView();` 생성
▶ ` <div ref={hasMorePosts && !loadPostsLoading ? ref : undefined}
          className="h-10"/>`를 만들어 ref가 있을 때마다 함수 호출함 
▶ 호출된 함수에는 lastId(가장 마지막에 호출된 게시글의 id)가 포함되어 있음 
` const lastId = mainPosts[mainPosts.length - 1]?.id;` 
▶ `pages/post/index.js`를 제외한 lastId가 적용된 `pages/hashtag/[tag].js`와 `pages/search/[content].js`는 redux로 값 전달 시 `data`로 전달한 부분을 변경함
▶ `data`에 `tag`와 `content`를 전달했다면,  lastId를 적용할 땐 각각 `{ lastId: lastId, data: tag }`와 `{ lastId: lastId, data: content }`로 전달함