### PR TITLE
4. UserInfo.js 내 게시글 개수 수정 5. 닉네임 변경 취소 버튼 수정 6. Bar 차트 크기 수정

### DIFF
--- a/prepare/front/components/NicknameEditForm.js
+++ b/prepare/front/components/NicknameEditForm.js
@@ -2,14 +2,16 @@ import React, { useCallback, useState } from "react";
 
 const NicknameEditForm = ({
   editMode,
-  nickname,
   onCancleChangeNickname,
+  nickname,
   onChangeNicknameEdit,
 }) => {
   const [editNickname, setEditNickname] = useState(nickname);
+
   const onEditNickname = useCallback((e) => {
     setEditNickname(e.target.value);
   }, []);
+
   return (
     <>
       {editMode ? (

--- a/prepare/front/components/Profile.js
+++ b/prepare/front/components/Profile.js
@@ -63,6 +63,10 @@ const Profile = ({ me, postResult, wordResult }) => {
     setEditMode(true);
   }, [id]);
 
+  const onCancleChangeNickname = useCallback(() => {
+    setEditMode(false);
+  }, []);
+
   const onClickFollowerModal = useCallback(() => {
     setFollowerModal(true);
   }, []);
@@ -208,6 +212,7 @@ const Profile = ({ me, postResult, wordResult }) => {
                   </div>
                   <div className="text-center mt-3">
                     <NicknameEditForm
+                      onCancleChangeNickname={onCancleChangeNickname}
                       editMode={editMode}
                       nickname={me?.nickname}
                       onChangeNicknameEdit={onChangeNicknameEdit}

--- a/prepare/front/components/UserInfo.js
+++ b/prepare/front/components/UserInfo.js
@@ -1,7 +1,21 @@
-import React from "react";
+import React, { useEffect } from "react";
 import Link from "next/link";
+import { useDispatch, useSelector } from "react-redux";
+import { loadPostsRequest } from "../redux/feature/postSlice";
 
-const UserInfo = ({ nickname, me, mainPosts }) => {
+const UserInfo = ({ nickname, me }) => {
+  const dispatch = useDispatch();
+  const { mainPosts, loadPostsLoading, hasMorePosts } = useSelector(
+    (state) => state.post
+  );
+
+  useEffect(() => {
+    if (hasMorePosts && !loadPostsLoading) {
+      const lastId = mainPosts[mainPosts.length - 1]?.id;
+      dispatch(loadPostsRequest(lastId));
+    }
+  }, [hasMorePosts, mainPosts]);
+
   return (
     <>
       <div className="ml-2 shadow shadow-black-500/40 rounded-xl">

--- a/prepare/front/components/profile/TodayChart.js
+++ b/prepare/front/components/profile/TodayChart.js
@@ -59,7 +59,7 @@ const TodayChart = () => {
       data: JSON.parse(a.score),
       datalabels: {
         // This code is used to display data values
-        anchor: "end",
+        anchor: "top",
         align: "top",
         formatter: Math.round,
         font: {
@@ -107,9 +107,11 @@ const TodayChart = () => {
       )}
       {lineChartData.datasets.length !== 0 && (
         <div>
-          <h1 className="font-bold">오늘의 결과</h1>
+          <h1 className="font-bold">오늘의 결과</h1>{" "}
           <p>(점수가 0인 경우 표에 표시되지 않습니다.)</p>
-          <Bar data={data} options={options}></Bar>
+          <div className="flex justify-center lg:w-6/12 lg:h-6/12 lg:mx-96">
+            <Bar data={data} options={options}></Bar>
+          </div>
         </div>
       )}
     </div>

--- a/prepare/front/pages/post/index.js
+++ b/prepare/front/pages/post/index.js
@@ -74,11 +74,7 @@ const Index = () => {
             <div className="col-span-1">
               {me && (
                 <>
-                  <UserInfo
-                    nickname={me?.nickname}
-                    me={me}
-                    mainPosts={mainPosts}
-                  />
+                  <UserInfo nickname={me?.nickname} me={me} />
                   <div
                     className="bg-gray-100 ml-2 mt-2 rounded-xl"
                     onClick={onBookmark}

--- a/prepare/front/pages/user/[id].js
+++ b/prepare/front/pages/user/[id].js
@@ -54,11 +54,7 @@ const User = () => {
       <div className="h-full mt-5">
         <div className="grid grid-cols-4 gap-6">
           <div className="col-span-1">
-            <UserInfo
-              nickname={userInfo?.nickname}
-              me={userInfo}
-              mainPosts={mainPosts}
-            />
+            <UserInfo nickname={userInfo?.nickname} me={userInfo} />
           </div>
           <div className="col-span-2">
             <div className="flex justify-center">


### PR DESCRIPTION
4. 기존 `mainPosts`로 개수를 구할 때, `userInVeiw`로 인해 10개씩만 호출되기 때문에 수정

▶ `loadPostsRequest`함수를 호출해 직접 게시글 개수 구하는 방법으로 변경

5.  닉네임 취소의 경우 해당 버튼에 적용되는 함수인 `onCancleChangeNickname`가 부모 컴포넌트인 `Profile.js`에서 선언되지 않았었음

▶ 함수를 만들고 `NicknameEditForm.js`에 전달함

6. 게임 완료 후 Bar 그래프 줄이기

▶ 웹화면이 1000이 넘어가는 경우(tailwindcss에서는 lg로 규정)
그래프 크기가 지나치게 커짐
▶ 그래프 크기를 절반으로 줄이고(`h-6/12 w-6/12`) 중앙에 배치함