### PR TITLE
1. profile.js ssr 적용 2. me에 포함된 정보로 게시글, 단어 개수 적용 3. password 제외 후 정보 전달

### DIFF
--- a/prepare/back/routes/user.js
+++ b/prepare/back/routes/user.js
@@ -6,7 +6,7 @@ const { Op } = require("sequelize");
 const fs = require("fs");
 const path = require("path");
 
-const { User, Post, Image, Comment } = require("../models");
+const { User, Post, Image, Comment, Word } = require("../models");
 const { isLoggedIn, isNotLoggedIn } = require("./middlewares");
 
 const router = express.Router();
@@ -42,7 +42,7 @@ router.get("/", upload.none(), async (req, res, next) => {
       const fullUserWithoutPassword = await User.findOne({
         where: { id: req.user.id },
         attributes: {
-          exclude: ["password"],
+          exclude: ["password", "createdAt", "updatedAt"],
         },
         include: [
           {
@@ -50,27 +50,40 @@ router.get("/", upload.none(), async (req, res, next) => {
             attributes: ["id"],
           },
           {
+            model: Word,
+            attributes: ["id"],
+          },
+          {
             model: User,
             as: "Followings",
-            attributes: ["id"],
+            attributes: {
+              exclude: ["createdAt", "updatedAt", "password"],
+            },
           },
           {
             model: User,
             as: "Blockings",
-            attributes: ["id"],
+            attributes: {
+              exclude: ["createdAt", "updatedAt", "password"],
+            },
           },
           {
             model: User,
             as: "Followers",
-            attributes: ["id"],
+            attributes: {
+              exclude: ["createdAt", "updatedAt", "password"],
+            },
           },
           {
             model: User,
             as: "Blockeds",
-            attributes: ["id"],
+            attributes: {
+              exclude: ["createdAt", "updatedAt", "password"],
+            },
           },
         ],
       });
+      console.log("fullUserWithoutPassword", fullUserWithoutPassword);
       res.status(200).json(fullUserWithoutPassword);
     } else {
       res.status(200).json(null);

--- a/prepare/front/components/BlockFollowModal.js
+++ b/prepare/front/components/BlockFollowModal.js
@@ -113,7 +113,7 @@ const BlockFollowModal = ({ setBlockFollowModal, blockInfo }) => {
                                     <div className="flex-shrink-0">
                                       <img
                                         className="ml-2 w-8 h-8 rounded-full"
-                                        src="/docs/images/people/profile-picture-1.jpg"
+                                        src={`http://localhost:3005/userImg/${block.profileImg}`}
                                         alt="Neil image"
                                       />
                                     </div>

--- a/prepare/front/components/FollowerModal.js
+++ b/prepare/front/components/FollowerModal.js
@@ -113,7 +113,7 @@ const FollowerModal = ({ setFollowerModal, followersInfo, followingsInfo }) => {
                                     <div className="flex-shrink-0">
                                       <img
                                         className="ml-2 w-8 h-8 rounded-full"
-                                        src="/docs/images/people/profile-picture-1.jpg"
+                                        src={`http://localhost:3005/userImg/${follower.profileImg}`}
                                         alt="Neil image"
                                       />
                                     </div>

--- a/prepare/front/components/FollowingModal.js
+++ b/prepare/front/components/FollowingModal.js
@@ -97,7 +97,7 @@ const FollowingModal = ({ setFollowingModal, followingsInfo }) => {
                                     <div className="flex-shrink-0">
                                       <img
                                         className="ml-2 w-8 h-8 rounded-full"
-                                        src="/docs/images/people/profile-picture-1.jpg"
+                                        src={`http://localhost:3005/userImg/${following.profileImg}`}
                                         alt="Neil image"
                                       />
                                     </div>

--- a/prepare/front/components/Profile.js
+++ b/prepare/front/components/Profile.js
@@ -18,9 +18,9 @@ import { loadGameRequest } from "../redux/feature/gameSlice";
 import AlertLoginModal from "./AletrtLoginModal";
 import TodayChart from "./profile/TodayChart";
 
-const Profile = ({ me, postResult, wordResult }) => {
+const Profile = () => {
   const dispatch = useDispatch();
-  const { imagePaths } = useSelector((state) => state.user);
+  const { me } = useSelector((state) => state.user);
   const { gameScore } = useSelector((state) => state.game);
   const id = useSelector((state) => state.user.me?.id);
 
@@ -36,7 +36,6 @@ const Profile = ({ me, postResult, wordResult }) => {
   }, [imageInput.current]);
 
   const onChangeImages = useCallback((e) => {
-    console.log("images", e.target.files);
     const imageFormData = new FormData();
     [].forEach.call(e.target.files, (f) => {
       imageFormData.append("image", f);
@@ -161,7 +160,7 @@ const Profile = ({ me, postResult, wordResult }) => {
                         <div className="mr-4 p-3 text-center">
                           <span className="text-xl font-bold block uppercase tracking-wide text-blueGray-600">
                             <Link href={`/post`}>
-                              <a> {postResult.length}</a>
+                              <a>{me.Posts.length}</a>
                             </Link>
                           </span>
                           <span className="text-sm text-blueGray-400">
@@ -222,7 +221,7 @@ const Profile = ({ me, postResult, wordResult }) => {
                         <div className="mr-4 p-3 text-center">
                           <span className="text-xl font-bold block uppercase tracking-wide">
                             <Link href={`/index`}>
-                              <a>{wordResult.length}</a>
+                              <a>{me.Words?.length}</a>
                             </Link>
                           </span>
                           <span className="text-sm text-blueGray-400">

--- a/prepare/front/components/UserInfo.js
+++ b/prepare/front/components/UserInfo.js
@@ -3,8 +3,9 @@ import Link from "next/link";
 import { useDispatch, useSelector } from "react-redux";
 import { loadPostsRequest } from "../redux/feature/postSlice";
 
-const UserInfo = ({ nickname, me }) => {
+const UserInfo = () => {
   const dispatch = useDispatch();
+  const { me } = useSelector((state) => state.user);
   const { mainPosts, loadPostsLoading, hasMorePosts } = useSelector(
     (state) => state.post
   );
@@ -34,7 +35,7 @@ const UserInfo = ({ nickname, me }) => {
             />
           )}
           <div className="ml-1">
-            <p className="font-bold p-1 mt-1 lg:mt-5">{nickname}</p>
+            <p className="font-bold p-1 mt-1 lg:mt-5">{me.nickname}</p>
           </div>
         </div>
         <div className="text-center lg:flex md:ml-5 lg:ml-10">
@@ -48,9 +49,7 @@ const UserInfo = ({ nickname, me }) => {
                 }}
                 prefetch={false}
               >
-                <a>
-                  {mainPosts?.filter((post) => post.UserId === me?.id).length}
-                </a>
+                <a>{me.Posts.length}</a>
               </Link>
             </p>
           </div>
@@ -58,11 +57,7 @@ const UserInfo = ({ nickname, me }) => {
             <p className="text-gray-400 block">Follower</p>
             <p className="ml-1 font-bold cursor-pointer">
               <Link href={`/profile`}>
-                <a>
-                  {me?.Followers.length >= 0
-                    ? me?.Followers.length
-                    : me?.Followers}
-                </a>
+                <a>{me?.Followers.length >= 0 ? me?.Followers.length : 0}</a>
               </Link>
             </p>
           </div>
@@ -70,11 +65,7 @@ const UserInfo = ({ nickname, me }) => {
             <p className="text-gray-400 block">Following</p>
             <p className="ml-1 font-bold cursor-pointer">
               <Link href={`/profile`}>
-                <a>
-                  {me?.Followings.length >= 0
-                    ? me?.Followings.length
-                    : me?.Followings}
-                </a>
+                <a>{me?.Followings.length >= 0 ? me?.Followings.length : 0}</a>
               </Link>
             </p>
           </div>

--- a/prepare/front/pages/bookmark.js
+++ b/prepare/front/pages/bookmark.js
@@ -64,11 +64,7 @@ const bookmark = () => {
           <div className="h-full mt-5">
             <div className="grid grid-cols-4 gap-6">
               <div className="col-span-1">
-                <UserInfo
-                  nickname={me?.nickname}
-                  me={me}
-                  postResult={postResult}
-                />
+                <UserInfo />
                 <div
                   className="bg-gray-100 ml-2 mt-2 rounded-xl"
                   onClick={onPost}

--- a/prepare/front/pages/post/index.js
+++ b/prepare/front/pages/post/index.js
@@ -74,7 +74,7 @@ const Index = () => {
             <div className="col-span-1">
               {me && (
                 <>
-                  <UserInfo nickname={me?.nickname} me={me} />
+                  <UserInfo />
                   <div
                     className="bg-gray-100 ml-2 mt-2 rounded-xl"
                     onClick={onBookmark}

--- a/prepare/front/pages/profile.js
+++ b/prepare/front/pages/profile.js
@@ -1,69 +1,36 @@
-import React, { useEffect } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import axios from "axios";
+import React from "react";
+import { useSelector } from "react-redux";
+import { END } from "redux-saga";
+
 import NavbarForm from "../components/NavbarForm";
 import LoginForm from "../components/LoginForm";
 import Profile from "../components/Profile";
-import { loadPostsRequest } from "../redux/feature/postSlice";
 import { loadMyInfoRequest } from "../redux/feature/userSlice";
-import { loadWordsRequest } from "../redux/feature/wordSlice";
-// import wrapper from "../redux/store";
-// import axios from "axios";
-// import { END } from "redux-saga";
+import wrapper from "../redux/store";
 
 const profile = () => {
-  const dispatch = useDispatch();
   const { me } = useSelector((state) => state.user);
-  const { mainPosts, loadPostsLoading, hasMorePosts } = useSelector(
-    (state) => state.post
-  );
-  const { wordLists, loadWordsLoading, hasMoreWords } = useSelector(
-    (state) => state.word
-  );
-
-  const id = useSelector((state) => state.user.me?.id);
-  const { imagePaths } = useSelector((state) => state.user);
-  const postResult = mainPosts.filter((post) => post.UserId === id);
-  const wordResult = wordLists.filter((word) => word.UserId === id);
-
-  useEffect(() => {
-    if (hasMorePosts && !loadPostsLoading) {
-      const lastId = mainPosts[mainPosts.length - 1]?.id;
-      dispatch(loadPostsRequest(lastId));
-      dispatch(loadWordsRequest());
-    }
-  }, [hasMorePosts, mainPosts]);
-
-  useEffect(() => {
-    dispatch(loadMyInfoRequest());
-  }, [imagePaths]);
 
   return (
     <>
-      <NavbarForm>
-        {me ? (
-          <Profile me={me} postResult={postResult} wordResult={wordResult} />
-        ) : (
-          <LoginForm />
-        )}
-      </NavbarForm>
+      <NavbarForm>{me ? <Profile /> : <LoginForm />}</NavbarForm>
     </>
   );
 };
 
-// export const getServerSideProps = wrapper.getServerSideProps(
-//   async (context) => {
-//     const cookie = context.req ? context.req.headers.cookie : "";
-//     axios.defaults.headers.Cookie = "";
-//     if (context.req && cookie) {
-//       axios.defaults.headers.Cookie = cookie;
-//     }
+export const getServerSideProps = wrapper.getServerSideProps(
+  async (context) => {
+    const cookie = context.req ? context.req.headers.cookie : "";
+    axios.defaults.headers.Cookie = "";
+    if (context.req && cookie) {
+      axios.defaults.headers.Cookie = cookie;
+    }
 
-//     context.store.dispatch(loadMyInfoRequest());
-//     context.store.dispatch(loadPostsRequest());
-//     context.store.dispatch(loadWordsRequest());
-//     context.store.dispatch(END);
-//     await context.store.sagaTask.toPromise();
-//   }
-// );
+    context.store.dispatch(loadMyInfoRequest());
+    context.store.dispatch(END);
+    await context.store.sagaTask.toPromise();
+  }
+);
 
 export default profile;

--- a/prepare/front/pages/user/[id].js
+++ b/prepare/front/pages/user/[id].js
@@ -54,7 +54,7 @@ const User = () => {
       <div className="h-full mt-5">
         <div className="grid grid-cols-4 gap-6">
           <div className="col-span-1">
-            <UserInfo nickname={userInfo?.nickname} me={userInfo} />
+            <UserInfo />
           </div>
           <div className="col-span-2">
             <div className="flex justify-center">

--- a/prepare/front/redux/feature/userSlice.js
+++ b/prepare/front/redux/feature/userSlice.js
@@ -112,9 +112,11 @@ export const userSlice = createSlice({
       state.loadMyInfoComplete = false;
     },
     loadMyInfoSuccess: (state, action) => {
+      const data = action.payload;
+      console.log("data", data);
       state.loadMyInfoLoading = false;
       state.loadMyInfoComplete = true;
-      state.me = action.payload;
+      state.me = data;
     },
     loadMyInfoFailure: (state, action) => {
       state.loadMyInfoLoading = false;


### PR DESCRIPTION
1. 부모 컴포넌트인 `pages/profile.js`에서 로그인한 유저의 여러 정보가 담긴`me` 정보를 전달x -> redux로 컴포넌트에서 바로 찾음

▶ 그 전에 ssr을 적용해 유저의 정보를 사전에 전달
▶ 차단, 팔로잉, 팔로워 관련 유저 이미지 보이게 수정(`userImg` 전달)

2. 1.에서 받은 정보로 게시글 개수는 `me.Posts.length`와 단어 개수는 `me.Words.length`로 나오게 함

▶ 정보 전달 시  `attributes: ["id"]`로 전달하게 함

3. `routes/user.js` 내 `attributes: ["id"]`가 아닌 `exclude`로 적용

▶ `id`값을 찾으니 그 안의 `password` 정보도 같이 포함됨
▶ `password`외 `createdAt`, `updatedAt` 정보도 제외해 프론트에 전달함