### PR TITLE
16. multer-s3와 aws-sdk 적용

### DIFF
--- a/prepare/back/routes/post.js
+++ b/prepare/back/routes/post.js
@@ -17,29 +17,18 @@ try {
   fs.mkdirSync("uploads");
 }
 
-// AWS.config.update({
-//   accessKeyId: process.env.S3_ACCESS_KEY_ID,
-//   secretAccessKey: process.env.S3_SECRET_ACCESS_KEY,
-//   region: "ap-northeast-2",
-// });
+AWS.config.update({
+  accessKeyId: process.env.S3_ACCESS_KEY_ID,
+  secretAccessKey: process.env.S3_SECRET_ACCESS_KEY,
+  region: "ap-northeast-2",
+});
 
 const upload = multer({
-  // storage: multerS3({
-  //   s3: new AWS.S3(),
-  //   bucket: "nodebird-seongong", //이 부분 주의할 것
-  //   key(req, file, cb) {
-  //     cb(null, `original/${Date.now()}_${path.basename(file.originalname)}`);
-  //   },
-  // }),
-  storage: multer.diskStorage({
-    destination(req, file, done) {
-      done(null, "uploads");
-    },
-    filename(req, file, done) {
-      //파일이미지.png
-      const ext = path.extname(file.originalname); //확장자 추출(.png)
-      const basename = path.basename(file.originalname, ext); //파일이미지
-      done(null, basename + "_" + new Date().getTime() + ext); //파일이미지1234849.png
+  storage: multerS3({
+    s3: new AWS.S3(),
+    bucket: "engword-s3", //버킷 이름
+    key(req, file, cb) {
+      cb(null, `original/${Date.now()}_${path.basename(file.originalname)}`);
     },
   }),
   limits: { fileSize: 20 * 1024 * 1024 }, // 20MB
@@ -123,7 +112,7 @@ router.post(
   upload.array("image"),
   async (req, res, next) => {
     console.log("req.files", req.files);
-    res.json(req.files.map((v) => v.filename));
+    res.json(req.files.map((v) => v.location));
   }
 );
 


### PR DESCRIPTION
16. aws에서 지원하는 `s3`로 이미지 업로드 방식 변경

▶ 기존 `multer`에 이미지 업로드 해 폴더에 업로드하는 방식과 큰 차이 없음 
▶ `multer-s3`와 `aws-sdk` 관련 코드 추가
▶ `post`에서 업로드하는 이미지는 `original` 폴더에 들어가고 `user`에서 업로드하는 이미지는 `original/userImg`에 들어감
▶ `filename`이 `loaction`으로 바뀌고 `req.file`이 `req.file.location`으로 바뀜