### PR TITLE
22. 기본 이미지는 thumb에 저장, 상세이미지는 original에서 가져오기

### DIFF
--- a/prepare/back/routes/post.js
+++ b/prepare/back/routes/post.js
@@ -115,7 +115,9 @@ router.post(
   upload.array("image"),
   async (req, res, next) => {
     console.log("req.files", req.files);
-    res.json(req.files.map((v) => v.location));
+    res.json(
+      req.files.map((v) => v.location.replace(/\/original\//, "/thumb/"))
+    );
   }
 );
 

--- a/prepare/front/components/post/ImagesZoomModal.js
+++ b/prepare/front/components/post/ImagesZoomModal.js
@@ -69,7 +69,10 @@ const ImagesZoomModal = ({ showNum, showImg, images, onClose }) => {
                               {mainImage ? (
                                 <img
                                   className="h-full w-full rounded-lg object-cover"
-                                  src={`${showImg}`}
+                                  src={`${showImg.replace(
+                                    /\/thumb\//,
+                                    "/original/"
+                                  )}`}
                                   alt={showImg}
                                 />
                               ) : null}
@@ -81,12 +84,14 @@ const ImagesZoomModal = ({ showNum, showImg, images, onClose }) => {
                                         className={`h-full w-full rounded-lg relative ${
                                           num === i ? null : "hidden"
                                         }`}
-                                        // className={`h-[50vh] relative`}
                                         key={v.id}
                                       >
                                         <img
                                           className="h-full w-full rounded-lg object-cover"
-                                          src={`${v.src}`}
+                                          src={`${v.src.replace(
+                                            /\/thumb\//,
+                                            "/original/"
+                                          )}`}
                                           alt={v?.src}
                                         />
                                       </li>


### PR DESCRIPTION
22. 정규표현식 이용해 이미지 저장할 위치 바꾸기

▶ `routes/post.js`의 경우 `original` 저장된 이미지들을 `thumb`으로 이동
▶ 반면 이미지 크게 보기(`components/ImagesZoomModal.js`)의 경우 원본 이미지를 보여줘야 하므로  `thumb` 저장된 이미지들을 `original`로 이동