### PR TITLE
30. 단어 중복 호출 문제 해결 31. 한국어 기초사전 API 검색 오류 해결

### DIFF
--- a/prepare/back/axdata.js
+++ b/prepare/back/axdata.js
@@ -38,6 +38,8 @@ const axdata = async (wordName, callback) => {
     const obj = JSON.parse(xmlToJson);
     const word = obj.channel.item;
 
+    console.log("word", word);
+
     //없는 단어 입력 시
     if (word === undefined) {
       korean = wordName;
@@ -80,11 +82,19 @@ const axdata = async (wordName, callback) => {
           }
         } else if (word[0].sense !== undefined) {
           // //뜻이 여러 개인 경우(오늘, 내일)
-          korean_dfn = word[0].sense[0].definition._text;
-          english = word[0].sense[0].translation.trans_word._cdata;
-          english_dfn = word[0].sense[0].translation.trans_dfn._cdata;
-          ex_english = word[0].sense[1].translation.trans_word._cdata;
-          ex_english_dfn = word[0].sense[0].translation.trans_dfn._cdata;
+          if (word[0].sense[0] === undefined) {
+            korean_dfn = word[0].sense.definition._text;
+            english = word[0].sense.translation.trans_word._cdata;
+            english_dfn = word[0].sense.translation.trans_dfn._cdata;
+            ex_english = "";
+            ex_english_dfn = "";
+          } else if (word[0].sense[0] !== undefined) {
+            korean_dfn = word[0].sense[0].definition._text;
+            english = word[0].sense[0].translation.trans_word._cdata;
+            english_dfn = word[0].sense[0].translation.trans_dfn._cdata;
+            ex_english = word[0].sense[1].translation.trans_word._cdata;
+            ex_english_dfn = word[0].sense[0].translation.trans_dfn._cdata;
+          }
         }
       } else if (word.sense.length !== undefined && word.length > 1) {
         //단어도 뜻도 여러 개인 경우(사과)

--- a/prepare/back/routes/word.js
+++ b/prepare/back/routes/word.js
@@ -163,12 +163,18 @@ router.get("/search/:word", async (req, res, next) => {
 
 //API로 단어 검색
 router.get("/:korean", async (req, res, next) => {
-  await axdata(req.params.korean, (error, { wordLists } = {}) => {
-    if (error) {
-      res.send(error);
+  const result = await axdata(
+    req.params.korean,
+    (error, { wordLists } = {}) => {
+      if (error) {
+        res.send(error);
+      }
+      res.send(wordLists);
     }
-    res.send(wordLists);
-  });
+  );
+  if (result) {
+    return res.status(404).send("검색한 단어를 찾을 수 없습니다.");
+  }
 });
 
 module.exports = router;

--- a/prepare/back/routes/words.js
+++ b/prepare/back/routes/words.js
@@ -176,9 +176,11 @@ router.get("/weekend", async (req, res, next) => {
   }
 });
 
+// router.get("/game", async (req, res, next) => {
 router.get("/game", isLoggedIn, async (req, res, next) => {
   try {
     const where = { UserId: req.user.id };
+    // const where = { UserId: 1 };
     if (parseInt(req.query.lastId, 10)) {
       // 초기 로딩이 아닐 때
       where.id = { [Op.lt]: parseInt(req.query.lastId, 10) };
@@ -186,7 +188,7 @@ router.get("/game", isLoggedIn, async (req, res, next) => {
     const words = await Word.findAll({
       //모든 게시글 가져옴
       where,
-      limit: 8,
+      limit: 10,
       order: [
         ["createdAt", "DESC"], //최신 게시글부터
       ],
@@ -203,7 +205,6 @@ router.get("/game", isLoggedIn, async (req, res, next) => {
     if (!words) {
       return res.status(500).send("로그인을 다시 한 번 확인하세요");
     }
-    console.log("Result", words);
     res.status(200).json(words);
   } catch (error) {
     console.error(error);

--- a/prepare/front/components/game/StartWordList.js
+++ b/prepare/front/components/game/StartWordList.js
@@ -42,7 +42,7 @@ const StartWordList = ({ word, index }) => {
       <li className="my-2.5 flex w-[380px]">
         <div className="ml-2 w-1/2">
           <p className="text-sm font-medium text-slate-900 truncate">
-            ({index}) {word.english}
+            ({index + 1}) {word.english}
           </p>
         </div>
         <div className="ml-2 w-1/2">

--- a/prepare/front/pages/game.js
+++ b/prepare/front/pages/game.js
@@ -58,7 +58,6 @@ const game = () => {
   }, [inView, hasMoreWords, wordLists, loadWordsLoading]);
 
   useEffect(() => {
-    dispatch(loadWordListsRequest());
     dispatch(loadCheckedRequest());
   }, []);
 

--- a/prepare/front/redux/feature/wordSlice.js
+++ b/prepare/front/redux/feature/wordSlice.js
@@ -393,7 +393,7 @@ export const wordSlice = createSlice({
       state.loadWordListsLoading = false;
       state.loadWordListsComplete = true;
       state.wordLists = state.wordLists.concat(data);
-      state.hasMoreWords = data.length === 8;
+      state.hasMoreWords = data.length === 10;
     },
     loadWordListsFailure: (state, action) => {
       state.loadWordListsLoading = false;

--- a/prepare/front/redux/sagas/wordSaga.js
+++ b/prepare/front/redux/sagas/wordSaga.js
@@ -186,6 +186,7 @@ function loadWordListsAPI(data) {
 function* loadWordLists(action) {
   try {
     const data = action.payload;
+    console.log("data", data);
     const result = yield call(loadWordListsAPI, data);
     yield put(loadWordListsSuccess(result.data));
   } catch (error) {


### PR DESCRIPTION
30. 단어 중복 호출문제 해결하기

▶ `useEffect`에서 `loadWordListsRequest`를 호출해 총 2번 호출하는 문제가 있었었음

31. 한국어 기초사전 API 사용 중 `일상`이나 `시계` 등 단어 검색 시 오류 발생

▶ 한글말에 중복된 단어가 없는 경우와 중복단어가 있는 경우로 나뉨 (조건 : `word[0].sense[0] === undefine`과 `word[0].sense[0] !== undefine`)